### PR TITLE
prevent having `e` in x and y coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup-node ./src/index.ts --format esm --dts --sourcemap"
+    "build": "tsup-node ./src/index.ts --format esm --dts --sourcemap",
+    "format": "biome format --write ."
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ interface PickAndPlaceRow {
   rotation: number
 }
 
+const fixedDecimals = 7
+
 export const convertCircuitJsonToPickAndPlaceRows = (
   circuitJson: AnyCircuitElement[],
   opts: { flip_y_axis?: boolean } = {},
@@ -28,8 +30,8 @@ export const convertCircuitJsonToPickAndPlaceRows = (
       )
       rows.push({
         designator: source_component?.name ?? element.pcb_component_id,
-        mid_x: element.center.x,
-        mid_y: element.center.y * (opts.flip_y_axis ? -1 : 1),
+        mid_x: element.center.x.toFixed(fixedDecimals),
+        mid_y: (element.center.y * (opts.flip_y_axis ? -1 : 1)).toFixed(fixedDecimals),
         layer: element.layer,
         rotation: element.rotation,
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ interface PickAndPlaceRow {
   rotation: number
 }
 
-const fixedDecimals = 7
+const fixedDecimals = 3
 
 export const convertCircuitJsonToPickAndPlaceRows = (
   circuitJson: AnyCircuitElement[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ export const convertCircuitJsonToPickAndPlaceRows = (
       )
       rows.push({
         designator: source_component?.name ?? element.pcb_component_id,
-        mid_x: element.center.x.toFixed(fixedDecimals),
-        mid_y: (element.center.y * (opts.flip_y_axis ? -1 : 1)).toFixed(fixedDecimals),
+        mid_x: element.center.x,
+        mid_y: element.center.y * (opts.flip_y_axis ? -1 : 1),
         layer: element.layer,
         rotation: element.rotation,
       })
@@ -46,8 +46,8 @@ export const convertCircuitJsonToPickAndPlaceCsv = (
   Papa.unparse(
     convertCircuitJsonToPickAndPlaceRows(circuitJson).map((row) => ({
       Designator: row.designator,
-      "Mid X": row.mid_x,
-      "Mid Y": row.mid_y,
+      "Mid X": row.mid_x.toFixed(fixedDecimals),
+      "Mid Y": row.mid_y.toFixed(fixedDecimals),
       Layer: row.layer,
       Rotation: row.rotation,
     })),

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -54,7 +54,7 @@ describe("circuit-json-to-pnp-csv", () => {
   test("convertCircuitJsonToPickAndPlaceCsv", () => {
     const csv = convertCircuitJsonToPickAndPlaceCsv(sampleSoup)
     const expectedCsv =
-      "Designator,Mid X,Mid Y,Layer,Rotation\r\nR1,10.0000000,20.0000000,top,0\r\nC1,30.0000000,40.0000000,bottom,90"
+      "Designator,Mid X,Mid Y,Layer,Rotation\r\nR1,10.000,20.000,top,0\r\nC1,30.000,40.000,bottom,90"
     expect(csv).toBe(expectedCsv)
   })
 

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -54,7 +54,7 @@ describe("circuit-json-to-pnp-csv", () => {
   test("convertCircuitJsonToPickAndPlaceCsv", () => {
     const csv = convertCircuitJsonToPickAndPlaceCsv(sampleSoup)
     const expectedCsv =
-      "Designator,Mid X,Mid Y,Layer,Rotation\r\nR1,10,20,top,0\r\nC1,30,40,bottom,90"
+      "Designator,Mid X,Mid Y,Layer,Rotation\r\nR1,10.0000000,20.0000000,top,0\r\nC1,30.0000000,40.0000000,bottom,90"
     expect(csv).toBe(expectedCsv)
   })
 


### PR DESCRIPTION
This should correct import placement errors on JLCPCB.

Not sure if this could happen in the `rotation` field, might be needed there as well