### PR TITLE
fix: filter non-placeable components from pick-and-place CSV

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { type AnyCircuitElement, type LayerRef } from "circuit-json"
-import Papa from "papaparse"
 import { su } from "@tscircuit/soup-util"
+import type { AnyCircuitElement, LayerRef } from "circuit-json"
+import Papa from "papaparse"
 
 interface PickAndPlaceRow {
   designator: string
@@ -11,6 +11,31 @@ interface PickAndPlaceRow {
 }
 
 const fixedDecimals = 3
+
+const NON_PLACEABLE_FTYPES = new Set([
+  "simple_net",
+  "simple_ground",
+  "simple_power",
+])
+
+function isPlaceableComponent(
+  source: { name?: string; ftype?: string; footprint?: string },
+  pcbComponentId: string,
+): boolean {
+  if (NON_PLACEABLE_FTYPES.has(source.ftype ?? "")) return false
+
+  const name = source.name ?? pcbComponentId
+  if (/^pcb_component_\d+$/.test(name)) return false
+
+  const hasMeaningfulName =
+    !!source.name && !source.name.startsWith("pcb_component_")
+  const hasFtype = !!source.ftype
+  const hasFootprint = !!source.footprint
+
+  if (!hasMeaningfulName && !hasFtype && !hasFootprint) return false
+
+  return true
+}
 
 export const convertCircuitJsonToPickAndPlaceRows = (
   circuitJson: AnyCircuitElement[],
@@ -25,6 +50,11 @@ export const convertCircuitJsonToPickAndPlaceRows = (
         element.source_component_id,
       )
       if (!source_component) continue
+
+      if (
+        !isPlaceableComponent(source_component as any, element.pcb_component_id)
+      )
+        continue
 
       rows.push({
         designator: source_component?.name ?? element.pcb_component_id,


### PR DESCRIPTION
## Summary

Fixes tscircuit/tscircuit#3303 (Bug 1 - pick-and-place CSV side)

Companion PR to tscircuit/circuit-json-to-bom-csv#11 which fixes the same issue in the BOM CSV.

### Problem

`pick_and_place.csv` generated by `tsci export -f gerbers` includes rows for vias, bare-copper edge pads, and other non-placeable structures as if they were SMD components. A fab's assembly service would try to source and place parts for these entries.

### Changes

Add `isPlaceableComponent()` filter that excludes:
- Components with `ftype` in simple_net, simple_ground, simple_power
- Auto-generated names matching `pcb_component_N` (vias, bare structures)
- Entries with no meaningful name, no ftype, and no footprint

### Tests

All 5 existing tests pass. The filter is additive - only excludes non-placeable entries, never removes real components.

### Related

- tscircuit/tscircuit#3303 (parent issue)
- tscircuit/circuit-json-to-bom-csv#11 (companion BOM fix)